### PR TITLE
Add topics, simplify interface, and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "pubsub-bus"
 readme = "README.md"
 repository = "https://github.com/an-dr/pubsub-bus"
-version = "2.0.0"
+version = "3.0.0"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 Thread-safe one-to-many event system. Simple and easy to use. It just works (hopefully).
 
+Features:
+
+- 📃 Event Topic Filtering
+- 🔢 Unique event and publisher IDs
+- 🔀 Thread-safe
+- 🧱 No unsafe code
+
+## Table of Contents
+
 - [pubsub-bus](#pubsub-bus)
+    - [Table of Contents](#table-of-contents)
     - [⚙️ What it does (Without words)](#️-what-it-does-without-words)
     - [🚀 Quick Start](#-quick-start)
         - [1. Add the dependency to your `Cargo.toml`](#1-add-the-dependency-to-your-cargotoml)
@@ -31,7 +41,7 @@ pubsub-bus = "3.0.0"
 ```rust
 enum Commands {
     Atack { player_id: u32 },
-    Move { player_id: u32, x: f32, y: f32 },
+    Move { player_id: u32, dx: f32, dy: f32 },
 }
 
 #[derive(PartialEq)]
@@ -79,18 +89,18 @@ impl Publisher<Commands, TopicIds> for Input {
 ...
 
 let mut  input = Input::new();
-bus.add_publisher(&mut input);
+bus.add_publisher(&mut input, None); // None -> Auto assign ID
 
 ```
 
 ### 5. Send events
 
 ```rust
-impl Input {
-    pub fn send_move(&self, player_id: u32, x: f32, y: f32) {
-        self.emitter.publish(Commands::Move { player_id, x, y });
-    }
-}
+input.publish(  Commands::Move { dx: 1.0, dy: 2.0 }, 
+                Some(TopicIds::Player1) );
+                
+input.publish(  Commands::Atack, 
+                Some(TopicIds::Player2) );
 ```
 
 ## 📖 Examples
@@ -109,13 +119,15 @@ fn main() {
 
     bus.add_subscriber(player1);
     bus.add_subscriber(player2);
-    bus.add_publisher(&mut input);
+    bus.add_publisher(&mut input, Some(85)).unwrap();
 
     // Send some events
-    input.send_move(TopicIds::Player1, 1.0, 2.0);
-    input.send_move(TopicIds::Player2, 1.0, 2.0);
-    input.send_atack(TopicIds::Player2);
-    input.send_atack(TopicIds::Player1);
+    input.publish(Commands::Move { dx: 1.0, dy: 2.0 }, 
+                  Some(TopicIds::Player2));
+    input.publish(Commands::Move { dx: 1.0, dy: 2.0 }, 
+                  Some(TopicIds::Player1));
+    input.publish(Commands::Atack, Some(TopicIds::Player2));
+    input.publish(Commands::Atack, Some(TopicIds::Player1));
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Thread-safe one-to-many event system. Simple and easy to use. It just works (hop
 ### 1. Add the dependency to your `Cargo.toml`
 
 ```toml
-pubsub-bus = "2.0.0"
+pubsub-bus = "3.0.0"
 ```
 
 ### 2. Create your events and a bus

--- a/docs/README/structure.drawio.svg
+++ b/docs/README/structure.drawio.svg
@@ -1,195 +1,235 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="512px" height="202px" viewBox="-0.5 -0.5 512 202" content="&lt;mxfile&gt;&lt;diagram name=&quot;main&quot; id=&quot;RfGr8GAcQx7fFn0TS_dj&quot;&gt;3Vlbb9owFP41eaRy7ASSRy5hk7ZJ26pp695ycRKrIa6cQKG/fk5iQy6GkgIrhUpV/PnYjs93zueD0dB0sf7E3Kf4Gw1wokEQrDU00yBE0OL/C2BTAXAogIiRoILADrgnL7gCdYkuSYAzgVVQTmmSk6cm6NM0xX7ewFzG6HPTLKRJ0ACe3Ah3gHvfTbrobxLkcYVaJtjhnzGJYrmyDkSP5/qPEaPLVKynQRSWn6p74cq5hH0WuwF9rkHI0dCUUZpXT4v1FCeFa6XbktgDFv1iP8eP858hyw0yJoNqsnmfIdsdMpzm550aVlOv3GSJpRfKveYb6V8ccHeLJmV5TCOauomzQydxvkh4p84fQ5IkU5pQVo5FoVn8cTzLGX3EtZ5h+eE9R+5NRpbLIizszJ/0rxn9GP96GKx+TV6+/PCyeIAqu+Kla+EhPPIJ0wXO2YYbMJy4OVk1Y8gVoRht7cTQMWPupmbwREmaZ7WZvxcAN5BJJZND5hRocdPPnj9Ub6AeDe3maH0ImvupvCZG9XkNvTVRRpfMx52J+EPNuTuojEB1NBrdwHOgZk81y9acuTaxNGvO+50VFku1Q/Kr63EdawSfm5Ao5c8+H4N5nE1WmOWEK8VYdCxIEJQRy3BGXlyvnA/wtuCTT25ONHN2fFjK/OEL4bVK7sQiDcloBKIYNQB3UEcievsF545GaULDMMOnMqTcL7o1vTCO1AtBE7gDwBy9haW+EmKM+knIK/avSIhhnioh+2Pv9Ve9nMwMb0NmZNqdQ2Z0MBw1ub520VGcFR9GdJR29nUWKaOeRcrolCIFWucqUtDF1ENx2n1E9ZD5cxb1QNdfpJgfWC+URQq8Cr3oHNvDnhXJ8JSK5M160XmNy+mFIvA+ol7IbZxFLyyZfcL9gxPLjbVywOXEpFtBlvRNllmHwSMkI6RpXsOrz0EpiRI3ywSj2xuoolHeXOFAdpUTyAswKJaSEnfsDZK+h/m9DG+TqV3KP++u4pC8QItr13AQ7Ge8QWFfvuxuDs6BZs81G2ljngHgfullPiMeTyYIuidDPfWYL647ddhxeIvhqenA+VTJpG9hL3xHivYJaY0iXUWRcQaKlMeZ3qWon0xKn6U0bR3VfATb/BEUlY2HonFnyuZsXe+cbdRsBia2AkPFpgU99IYjvjpjDvgEdEuBQ3J07H1FocAGtK+oYju0e3XS8vIVfF96CcniImfPk69jx7FmSuXdMvxO+WrozXQFinTV7f+YrvAQOR1FRbevqEb7G+i7K6rii+oBisDtU9Q+9LZ0vBtFikusAxTpt09RO4suSRFv7n6nrQ6t3W/hyPkH&lt;/diagram&gt;&lt;/mxfile&gt;" style="background-color: rgb(255, 255, 255);">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="512px" height="202px" viewBox="-0.5 -0.5 512 202" content="&lt;mxfile&gt;&lt;diagram name=&quot;main&quot; id=&quot;RfGr8GAcQx7fFn0TS_dj&quot;&gt;7VpZb+M2EP41AtoHB7otPfrcAtsW2U0XbfpGSbQkRBZdSr7y60uKpHXRh9Zy4k3rALE4HFIk55tvhgMrxmS5+4TBKvoNBTBRdDXYKcZU0fXh0CL/qWDPBKbrMkGI44CJ1FLwFL9CJtSEdB0HMOMyJsoRSvJ4VRf6KE2hn9dkAGO0rastUBLUBCsQwpbgyQdJW/pnHOQRkzqWWsp/gXEYiTdrKu/xgP8SYrRO+fsU3VgUH9a9BGIurp9FIEDbisiYKcYEI5Szp+VuAhN6tOLYkshTHfTZ3UYv868LnJvxKB6wyeZdhhx2iGGa9zu1zqbegGQNxSkUe8334nxhQI6bNxHOIxSiFCSzUjqO8mVCOjXyuIiTZIIShIuxRmBBJzCJPMsxeoGVHkf3DNsmPRfuTSAL4BByPesr+tsKv4y+PQ8238avn794WTQwmB5ddAUe/EQ+QbSEOd4TBQwTkMebOoYAh2J40ONDRxiDfUVhheI0zyozP1IBUeBOZQjn4D6lqw3bdNMnD2wF8tG6Wx+t2Wp9P+zU+Kguy9AaE2VojX3Ymog8VA63FBUIlKPRbANvpivuRHFcZTZXxo7izKVQ/BV4hL9qoANJHKbk2ScQggRf4w3EeUwYYsQ7lnEQFEjFMItfgVfMp5I2tyOZ3Bor1pRIEjr9+MAMArEpSuHlYBVeRZYBdzIS5EuoEUkNnnzUQH3QNYNjuhtkS+MKFbRYZPBau0n3KzHmD8MiUj33Pllk2JFFhtewiO70xSLGzVjE+MgsIryqDxYhJHIli3BjCm67PalYPzCpSFMT/S5IxRw2vNM+TSpn9M+Qimn1RCqtZdyOVCTA+zikIjbXC6k4wicFOWjXccxOOuB2FGO3LD3bkOMbr7OWfY8TycKif1SO0rwiZx8ZwdjFh/SECcgybu/D7ZI2CgPDQHQVE4jLrc5fJYhPvdDy2hHLH7XwwcWat4Ftec02xOU4qlyxdfW4xWsm7Govt+2Zc1Vx54prKCPiAXaS0+NagbRmPPufNb2jF6c22PKFjohKivASJIXzCB3yFLJv9WntZT6OPeK3fGayaDa50GFiDzclvSzhD7SKfaZ1ZAG/U9c/gVSAfV6v0fQWqrrHw9M4vLRK0R2Hx2JIBYeaDIdmDziURnKtjUNuIHogxw2fFcagBtW01U5q9IKAJMCSRKBSR/I+D+EA4oHPzDgqVot/Ggyq8p8vhZ0n+h4TsK+5g9dEPpGxMxDiEykbj1wVwJK94/1fHKBF45k2HizRnO6qndP9d2O5l2DKccBSjxN4UdsZ4ql4dDZDLEOwqqvmdTG31yh7avdy1iarVx/XXhJnEQVWP1x2CMnHQ++5mHo8nN+K5swGy6ltlnP1NyQ5SWn4XoJtr3z3f8y+BZibNaB3j9mSUtG9wPldcChC+UdHYjN7PKDu3ZAoqZb/p5H4tM9yuOwt9js+9H0ZEj3HouWou+HEN0Viu9RxMjXvWk294NThLs6L1P5haPHms0jmyXOZ2dOGSOxhGozobwTK1JxI5jHdZtEfAJI3BnxN0uz5+9L4U+n52UKvKYfB29Z1Nceu4qOr/rm6rkPuHoZpOvrQcmxdHdajvdtA7MVVXqeRNjSh31+Vd9h2CHrHnirOROoZNy7uYpQTcCA6ylUvvJ9eXMSt+4B9kqVuWNcd9FDYJc3yFzdMvfxVkzH7Fw==&lt;/diagram&gt;&lt;/mxfile&gt;" style="background-color: rgb(255, 255, 255);">
     <defs/>
     <g>
-        <path d="M 270 91 L 270 86 Q 270 81 270 71 L 270 47.37" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 270 42.12 L 273.5 49.12 L 270 47.37 L 266.5 49.12 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 271 91 L 271 86 Q 271 81 271 71 L 271 47.37" fill="none" stroke="#82b366" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 271 42.12 L 274.5 49.12 L 271 47.37 L 267.5 49.12 Z" fill="#82b366" stroke="#82b366" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 72px; margin-left: 270px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                ✉️ Event
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 71px; margin-left: 271px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                ✉️
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="270" y="75" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    ✉️ Event
+                <text x="271" y="75" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    ✉️
                 </text>
             </switch>
         </g>
-        <path d="M 430 91 L 430 86 Q 430 81 430 71 L 430 47.37" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 430 42.12 L 433.5 49.12 L 430 47.37 L 426.5 49.12 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 271 111 L 271 141 Q 271 151 271 152.82 L 271 154.63" fill="none" stroke="#82b366" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 271 159.88 L 267.5 152.88 L 271 154.63 L 274.5 152.88 Z" fill="#82b366" stroke="#82b366" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 69px; margin-left: 429px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                ✉️ Event
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 131px; margin-left: 271px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                ✉️
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="429" y="72" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    ✉️ Event
+                <text x="271" y="134" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    ✉️
                 </text>
             </switch>
         </g>
-        <path d="M 270 111 L 270 141 Q 270 151 270 152.82 L 270 154.63" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 270 159.88 L 266.5 152.88 L 270 154.63 L 273.5 152.88 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 431 111 L 431 131 Q 431 141 431 147.82 L 431 154.63" fill="none" stroke="#82b366" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 431 159.88 L 427.5 152.88 L 431 154.63 L 434.5 152.88 Z" fill="#82b366" stroke="#82b366" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 133px; margin-left: 270px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                ✉️ Event
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 132px; margin-left: 431px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                ✉️
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="270" y="136" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    ✉️ Event
+                <text x="431" y="136" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    ✉️
                 </text>
             </switch>
         </g>
-        <path d="M 430 111 L 430 131 Q 430 141 430 147.82 L 430 154.63" fill="none" stroke="#666666" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 430 159.88 L 426.5 152.88 L 430 154.63 L 433.5 152.88 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="191" y="91" width="320" height="20" fill="#f5f5f5" stroke="#666666" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 132px; margin-left: 430px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                ✉️ Event
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="430" y="135" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    ✉️ Event
-                </text>
-            </switch>
-        </g>
-        <rect x="190" y="91" width="320" height="20" fill="#f5f5f5" stroke="#666666" stroke-width="2" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 101px; margin-left: 350px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 101px; margin-left: 351px;">
                         <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 EventBus
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="350" y="105" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                <text x="351" y="105" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     EventBus
                 </text>
             </switch>
         </g>
-        <rect x="210" y="161" width="120" height="40" fill="#c5e2fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <rect x="211" y="161" width="120" height="40" fill="#d5e8d4" stroke="#82b366" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 270px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 271px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">
-                                📫 Subscriber 2
+                                📫
+                                <span style="font-weight: normal;">
+                                    Subscriber
+                                </span>
+                                <br/>
+                                <span style="font-weight: normal;">
+                                    Topic:
+                                </span>
+                                None
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="270" y="185" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    📫 Subscriber 2
+                <text x="271" y="185" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    📫 Subscriber...
                 </text>
             </switch>
         </g>
-        <path d="M 120 101 L 183.63 101" fill="none" stroke="#82b366" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 188.88 101 L 181.88 104.5 L 183.63 101 L 181.88 97.5 Z" fill="#82b366" stroke="#82b366" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 93 101 L 184.63 101" fill="none" stroke="#82b366" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 189.88 101 L 182.88 104.5 L 184.63 101 L 182.88 97.5 Z" fill="#82b366" stroke="#82b366" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 101px; margin-left: 150px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
-                                ✉️ Event
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 101px; margin-left: 141px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <font style="font-size: 11px;">
+                                    Event
+                                    <br/>
+                                    ✉️
+                                    <br style="border-color: var(--border-color);"/>
+                                    Topic:
+                                    <b>
+                                        Player
+                                    </b>
+                                </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="150" y="104" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    ✉️ Event
+                <text x="141" y="104" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Event...
                 </text>
             </switch>
         </g>
-        <rect x="1" y="81" width="119" height="40" fill="#aee8d3" stroke="#82b366" stroke-width="2" pointer-events="all"/>
+        <rect x="1" y="81" width="92" height="40" fill="#f5f5f5" stroke="#666666" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 101px; margin-left: 61px;">
-                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 101px; margin-left: 47px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 📤 Publisher
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="61" y="105" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                <text x="47" y="105" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     📤 Publisher
                 </text>
             </switch>
         </g>
-        <rect x="370" y="161" width="120" height="40" fill="#c5e2fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <rect x="371" y="161" width="120" height="40" fill="#d5e8d4" stroke="#82b366" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 430px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 431px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">
-                                📫 Subscriber 3
+                                📫
+                                <span style="font-weight: normal;">
+                                    Subscriber
+                                </span>
+                                <br style="border-color: var(--border-color);"/>
+                                <span style="font-weight: normal;">
+                                    Topic:
+                                </span>
+                                None
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="430" y="185" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    📫 Subscriber 3
+                <text x="431" y="185" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    📫 Subscriber...
                 </text>
             </switch>
         </g>
-        <rect x="210" y="1" width="120" height="40" fill="#c5e2fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <rect x="211" y="1" width="120" height="40" fill="#d5e8d4" stroke="#82b366" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 21px; margin-left: 270px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 21px; margin-left: 271px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">
-                                📫 Subscriber 0
+                                📫
+                                <span style="font-weight: normal;">
+                                    Subscriber
+                                </span>
+                                <br/>
+                                <span style="font-weight: normal;">
+                                    Topic:
+                                </span>
+                                Player
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="270" y="25" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    📫 Subscriber 0
+                <text x="271" y="25" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    📫 Subscriber...
                 </text>
             </switch>
         </g>
-        <rect x="370" y="1" width="120" height="40" fill="#c5e2fc" stroke="#6c8ebf" stroke-width="2" pointer-events="all"/>
+        <rect x="371" y="1" width="120" height="40" fill="#f8cecc" stroke="#b85450" stroke-width="2" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 21px; margin-left: 430px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 21px; margin-left: 431px;">
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap;">
-                                📫 Subscriber 1
+                                📫
+                                <span style="font-weight: normal;">
+                                    Subscriber
+                                </span>
+                                <br/>
+                                <span style="font-weight: normal;">
+                                    Topic:
+                                </span>
+                                System
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="430" y="25" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    📫 Subscriber 1
+                <text x="431" y="25" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
+                    📫 Subscriber...
+                </text>
+            </switch>
+        </g>
+        <path d="M 431 91 L 431 77 Q 431 67 431 57 L 431 41" fill="none" stroke="#b85450" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <g transform="translate(-0.5 -0.5)rotate(90 430.5833333333335 70.58333333333337)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 71px; margin-left: 431px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                ❌
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="431" y="74" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    ❌
                 </text>
             </switch>
         </g>

--- a/examples/basic_game_events/commands.rs
+++ b/examples/basic_game_events/commands.rs
@@ -1,4 +1,4 @@
 pub enum Commands {
-    Atack { player_id: u32 },
-    Move { player_id: u32, x: f32, y: f32 },
+    Atack,
+    Move { dx: f32, dy: f32 },
 }

--- a/examples/basic_game_events/input.rs
+++ b/examples/basic_game_events/input.rs
@@ -1,13 +1,11 @@
-use core::panic;
-
 use crate::commands::Commands;
-use crate::topic_ids::*;
+use crate::topic_ids::TopicIds;
 use pubsub_bus::*;
 
 #[allow(dead_code)] // allow dead code for illustrative purposes
 pub struct Input {
     device: String, // E.g. "keyboard", "mouse", "gamepad"
-    emitter: EventEmitter<Commands, String>,
+    emitter: EventEmitter<Commands, TopicIds>,
 }
 
 impl Input {
@@ -18,29 +16,27 @@ impl Input {
         }
     }
 
-    pub fn send_move(&mut self, topic: &str, x: f32, y: f32) {
+    pub fn send_move(&mut self, topic: TopicIds, x: f32, y: f32) {
         let player_id = match topic {
-            TOPIC_PLAYER_1 => 1,
-            TOPIC_PLAYER_2 => 2,
-            _ => panic!("Unknown topic"),
+            TopicIds::Player1 => 1,
+            TopicIds::Player2 => 2,
         };
         let event = Commands::Move { player_id, x, y };
-        self.emitter.publish(event, Some(topic.to_string()));
+        self.emitter.publish(event, Some(topic));
     }
 
-    pub fn send_atack(&mut self, topic: &str) {
+    pub fn send_atack(&mut self, topic: TopicIds) {
         let player_id = match topic {
-            TOPIC_PLAYER_1 => 1,
-            TOPIC_PLAYER_2 => 2,
-            _ => panic!("Unknown topic"),
+            TopicIds::Player1 => 1,
+            TopicIds::Player2 => 2,
         };
         let event = Commands::Atack { player_id };
-        self.emitter.publish(event, Some(topic.to_string()));
+        self.emitter.publish(event, Some(topic));
     }
 }
 
-impl Publisher<Commands, String> for Input {
-    fn get_mut_emitter(&mut self) -> &mut EventEmitter<Commands, String> {
+impl Publisher<Commands, TopicIds> for Input {
+    fn get_mut_emitter(&mut self) -> &mut EventEmitter<Commands, TopicIds> {
         &mut self.emitter
     }
 }

--- a/examples/basic_game_events/input.rs
+++ b/examples/basic_game_events/input.rs
@@ -15,24 +15,6 @@ impl Input {
             emitter: EventEmitter::new(),
         }
     }
-
-    pub fn send_move(&mut self, topic: TopicIds, x: f32, y: f32) {
-        let player_id = match topic {
-            TopicIds::Player1 => 1,
-            TopicIds::Player2 => 2,
-        };
-        let event = Commands::Move { player_id, x, y };
-        self.emitter.publish(event, Some(topic));
-    }
-
-    pub fn send_atack(&mut self, topic: TopicIds) {
-        let player_id = match topic {
-            TopicIds::Player1 => 1,
-            TopicIds::Player2 => 2,
-        };
-        let event = Commands::Atack { player_id };
-        self.emitter.publish(event, Some(topic));
-    }
 }
 
 impl Publisher<Commands, TopicIds> for Input {

--- a/examples/basic_game_events/input.rs
+++ b/examples/basic_game_events/input.rs
@@ -1,4 +1,7 @@
+use core::panic;
+
 use crate::commands::Commands;
+use crate::topic_ids::*;
 use pubsub_bus::*;
 
 #[allow(dead_code)] // allow dead code for illustrative purposes
@@ -15,16 +18,24 @@ impl Input {
         }
     }
 
-    pub fn send_move(&mut self, player_id: u32, x: f32, y: f32) {
+    pub fn send_move(&mut self, topic: u32, x: f32, y: f32) {
+        let player_id = match topic {
+            TOPIC_PLAYER_1 => 1,
+            TOPIC_PLAYER_2 => 2,
+            _ => panic!("Unknown topic"),
+        };
         let event = Commands::Move { player_id, x, y };
-
-        self.emitter.publish(event, None);
+        self.emitter.publish(event, Some(topic));
     }
 
-    pub fn send_atack(&mut self, player_id: u32) {
+    pub fn send_atack(&mut self, topic: u32) {
+        let player_id = match topic {
+            TOPIC_PLAYER_1 => 1,
+            TOPIC_PLAYER_2 => 2,
+            _ => panic!("Unknown topic"),
+        };
         let event = Commands::Atack { player_id };
-
-        self.emitter.publish(event, None);
+        self.emitter.publish(event, Some(topic));
     }
 }
 

--- a/examples/basic_game_events/input.rs
+++ b/examples/basic_game_events/input.rs
@@ -18,13 +18,13 @@ impl Input {
     pub fn send_move(&mut self, player_id: u32, x: f32, y: f32) {
         let event = Commands::Move { player_id, x, y };
 
-        self.emitter.publish(event);
+        self.emitter.publish(event, None);
     }
 
     pub fn send_atack(&mut self, player_id: u32) {
         let event = Commands::Atack { player_id };
 
-        self.emitter.publish(event);
+        self.emitter.publish(event, None);
     }
 }
 

--- a/examples/basic_game_events/input.rs
+++ b/examples/basic_game_events/input.rs
@@ -7,7 +7,7 @@ use pubsub_bus::*;
 #[allow(dead_code)] // allow dead code for illustrative purposes
 pub struct Input {
     device: String, // E.g. "keyboard", "mouse", "gamepad"
-    emitter: EventEmitter<Commands, u32>,
+    emitter: EventEmitter<Commands, String>,
 }
 
 impl Input {
@@ -18,29 +18,29 @@ impl Input {
         }
     }
 
-    pub fn send_move(&mut self, topic: u32, x: f32, y: f32) {
+    pub fn send_move(&mut self, topic: &str, x: f32, y: f32) {
         let player_id = match topic {
             TOPIC_PLAYER_1 => 1,
             TOPIC_PLAYER_2 => 2,
             _ => panic!("Unknown topic"),
         };
         let event = Commands::Move { player_id, x, y };
-        self.emitter.publish(event, Some(topic));
+        self.emitter.publish(event, Some(topic.to_string()));
     }
 
-    pub fn send_atack(&mut self, topic: u32) {
+    pub fn send_atack(&mut self, topic: &str) {
         let player_id = match topic {
             TOPIC_PLAYER_1 => 1,
             TOPIC_PLAYER_2 => 2,
             _ => panic!("Unknown topic"),
         };
         let event = Commands::Atack { player_id };
-        self.emitter.publish(event, Some(topic));
+        self.emitter.publish(event, Some(topic.to_string()));
     }
 }
 
-impl Publisher<Commands, u32> for Input {
-    fn get_mut_emitter(&mut self) -> &mut EventEmitter<Commands, u32> {
+impl Publisher<Commands, String> for Input {
+    fn get_mut_emitter(&mut self) -> &mut EventEmitter<Commands, String> {
         &mut self.emitter
     }
 }

--- a/examples/basic_game_events/input.rs
+++ b/examples/basic_game_events/input.rs
@@ -7,7 +7,7 @@ use pubsub_bus::*;
 #[allow(dead_code)] // allow dead code for illustrative purposes
 pub struct Input {
     device: String, // E.g. "keyboard", "mouse", "gamepad"
-    emitter: EventEmitter<Commands>,
+    emitter: EventEmitter<Commands, u32>,
 }
 
 impl Input {
@@ -39,8 +39,8 @@ impl Input {
     }
 }
 
-impl Publisher<Commands> for Input {
-    fn get_mut_emitter(&mut self) -> &mut EventEmitter<Commands> {
+impl Publisher<Commands, u32> for Input {
+    fn get_mut_emitter(&mut self) -> &mut EventEmitter<Commands, u32> {
         &mut self.emitter
     }
 }

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -11,7 +11,7 @@ use topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2};
 
 fn main() {
     // Create a bus
-    let bus: Arc<EventBus<Commands, u32>> = Arc::new(EventBus::new());
+    let bus: Arc<EventBus<Commands, String>> = Arc::new(EventBus::new());
 
     // Create players and subscribe them to the bus
     let player1 = Arc::new(Mutex::new(Player { id: 1 }));

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -20,11 +20,11 @@ fn main() {
 
     bus.add_subscriber(player1);
     bus.add_subscriber(player2);
-    bus.add_publisher(&mut input);
+    bus.add_publisher(&mut input, Some(85)).unwrap();
 
     // Send some events
-    input.send_move(TopicIds::Player1, 1.0, 2.0);
-    input.send_move(TopicIds::Player2, 1.0, 2.0);
-    input.send_atack(TopicIds::Player2);
-    input.send_atack(TopicIds::Player1);
+    input.publish(Commands::Move { dx: 1.0, dy: 2.0 }, Some(TopicIds::Player2));
+    input.publish(Commands::Move { dx: 1.0, dy: 2.0 }, Some(TopicIds::Player1));
+    input.publish(Commands::Atack, Some(TopicIds::Player2));
+    input.publish(Commands::Atack, Some(TopicIds::Player1));
 }

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -7,23 +7,20 @@ use commands::Commands;
 use input::Input;
 use player::Player;
 use pubsub_bus::*;
-use std::sync::{Arc, Mutex};
 use topic_ids::TopicIds;
 
 fn main() {
     // Create a bus
     let bus: EventBus<Commands, TopicIds> = EventBus::new();
 
-    // Create players and subscribe them to the bus
-    let player1 = Arc::new(Mutex::new(Player { id: 1 }));
-    let player2 = Arc::new(Mutex::new(Player { id: 2 }));
+    // Create players, input, and attach to the bus
+    let player1 = Player { id: 1 };
+    let player2 = Player { id: 2 };
     let mut input = Input::new();
 
     bus.add_subscriber(player1);
     bus.add_subscriber(player2);
     bus.add_publisher(&mut input);
-
-    // Create an input and connect it to the bus
 
     // Send some events
     input.send_move(TopicIds::Player1, 1.0, 2.0);

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -2,16 +2,17 @@ mod commands;
 mod input;
 mod player;
 mod topic_ids;
+
 use commands::Commands;
 use input::Input;
 use player::Player;
 use pubsub_bus::*;
 use std::sync::{Arc, Mutex};
-use topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2};
+use topic_ids::TopicIds;
 
 fn main() {
     // Create a bus
-    let bus: EventBus<Commands, String> = EventBus::new();
+    let bus: EventBus<Commands, TopicIds> = EventBus::new();
 
     // Create players and subscribe them to the bus
     let player1 = Arc::new(Mutex::new(Player { id: 1 }));
@@ -25,8 +26,8 @@ fn main() {
     // Create an input and connect it to the bus
 
     // Send some events
-    input.send_move(TOPIC_PLAYER_1, 1.0, 2.0);
-    input.send_move(TOPIC_PLAYER_2, 1.0, 2.0);
-    input.send_atack(TOPIC_PLAYER_2);
-    input.send_atack(TOPIC_PLAYER_1);
+    input.send_move(TopicIds::Player1, 1.0, 2.0);
+    input.send_move(TopicIds::Player2, 1.0, 2.0);
+    input.send_atack(TopicIds::Player2);
+    input.send_atack(TopicIds::Player1);
 }

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -11,7 +11,7 @@ use topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2};
 
 fn main() {
     // Create a bus
-    let bus: Arc<EventBus<Commands>> = Arc::new(EventBus::new());
+    let bus: Arc<EventBus<Commands, u32>> = Arc::new(EventBus::new());
 
     // Create players and subscribe them to the bus
     let player1 = Arc::new(Mutex::new(Player { id: 1 }));

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -1,11 +1,13 @@
 mod commands;
 mod input;
 mod player;
+mod topic_ids;
 use commands::Commands;
 use input::Input;
 use player::Player;
 use pubsub_bus::*;
 use std::sync::{Arc, Mutex};
+use topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2};
 
 fn main() {
     // Create a bus
@@ -23,6 +25,8 @@ fn main() {
     // Create an input and connect it to the bus
 
     // Send some events
-    input.send_move(1, 1.0, 2.0);
-    input.send_atack(2);
+    input.send_move(TOPIC_PLAYER_1, 1.0, 2.0);
+    input.send_move(TOPIC_PLAYER_2, 1.0, 2.0);
+    input.send_atack(TOPIC_PLAYER_2);
+    input.send_atack(TOPIC_PLAYER_1);
 }

--- a/examples/basic_game_events/main.rs
+++ b/examples/basic_game_events/main.rs
@@ -11,7 +11,7 @@ use topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2};
 
 fn main() {
     // Create a bus
-    let bus: Arc<EventBus<Commands, String>> = Arc::new(EventBus::new());
+    let bus: EventBus<Commands, String> = EventBus::new();
 
     // Create players and subscribe them to the bus
     let player1 = Arc::new(Mutex::new(Player { id: 1 }));

--- a/examples/basic_game_events/player.rs
+++ b/examples/basic_game_events/player.rs
@@ -1,4 +1,7 @@
-use crate::commands::Commands;
+use crate::{
+    commands::Commands,
+    topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2},
+};
 use pubsub_bus::*;
 
 pub struct Player {
@@ -11,23 +14,27 @@ impl Subscriber<Commands> for Player {
         let event_source_id = event.get_source_id();
         match event.get_content() {
             Commands::Move { player_id, x, y } => {
-                if *player_id != self.id {
-                    return;
-                }
                 println!(
-                    "Received event {} from {}: Move({}, {}, {})",
-                    event_id, event_source_id, player_id, x, y
+                    "[Player {}] Received event {} from {}: Move({}, {}, {})",
+                    self.id, event_id, event_source_id, player_id, x, y
                 );
             }
             Commands::Atack { player_id } => {
-                if *player_id != self.id {
-                    return;
-                }
                 println!(
-                    "Received event {} from {}: Atack({})",
-                    event_id, event_source_id, player_id
+                    "[Player {}] Received event {} from {}: Atack({})",
+                    self.id, event_id, event_source_id, player_id
                 );
             }
         }
+    }
+
+    fn get_subscribed_topics(&self) -> Option<Vec<u32>> {
+        if self.id == 1 {
+            return Some(vec![TOPIC_PLAYER_1]);
+        }
+        if self.id == 2 {
+            return Some(vec![TOPIC_PLAYER_2]);
+        }
+        None
     }
 }

--- a/examples/basic_game_events/player.rs
+++ b/examples/basic_game_events/player.rs
@@ -1,6 +1,5 @@
 use crate::{
-    commands::Commands,
-    topic_ids::{TOPIC_PLAYER_1, TOPIC_PLAYER_2},
+    commands::Commands, topic_ids::TopicIds,
 };
 use pubsub_bus::*;
 
@@ -8,8 +7,8 @@ pub struct Player {
     pub id: u32,
 }
 
-impl Subscriber<Commands, String> for Player {
-    fn on_event(&mut self, event: &BusEvent<Commands, String>) {
+impl Subscriber<Commands, TopicIds> for Player {
+    fn on_event(&mut self, event: &BusEvent<Commands, TopicIds>) {
         let event_id = event.get_id();
         let event_source_id = event.get_source_id();
         match event.get_content() {
@@ -28,12 +27,12 @@ impl Subscriber<Commands, String> for Player {
         }
     }
 
-    fn get_subscribed_topics(&self) -> Option<Vec<String>> {
+    fn get_subscribed_topics(&self) -> Option<Vec<TopicIds>> {
         if self.id == 1 {
-            return Some(vec![TOPIC_PLAYER_1.to_string()]);
+            return Some(vec![TopicIds::Player1]);
         }
         if self.id == 2 {
-            return Some(vec![TOPIC_PLAYER_2.to_string()]);
+            return Some(vec![TopicIds::Player2]);
         }
         None
     }

--- a/examples/basic_game_events/player.rs
+++ b/examples/basic_game_events/player.rs
@@ -8,8 +8,8 @@ pub struct Player {
     pub id: u32,
 }
 
-impl Subscriber<Commands> for Player {
-    fn on_event(&mut self, event: &Event<Commands>) {
+impl Subscriber<Commands, u32> for Player {
+    fn on_event(&mut self, event: &Event<Commands, u32>) {
         let event_id = event.get_id();
         let event_source_id = event.get_source_id();
         match event.get_content() {

--- a/examples/basic_game_events/player.rs
+++ b/examples/basic_game_events/player.rs
@@ -8,8 +8,8 @@ pub struct Player {
     pub id: u32,
 }
 
-impl Subscriber<Commands, u32> for Player {
-    fn on_event(&mut self, event: &Event<Commands, u32>) {
+impl Subscriber<Commands, String> for Player {
+    fn on_event(&mut self, event: &BusEvent<Commands, String>) {
         let event_id = event.get_id();
         let event_source_id = event.get_source_id();
         match event.get_content() {
@@ -28,12 +28,12 @@ impl Subscriber<Commands, u32> for Player {
         }
     }
 
-    fn get_subscribed_topics(&self) -> Option<Vec<u32>> {
+    fn get_subscribed_topics(&self) -> Option<Vec<String>> {
         if self.id == 1 {
-            return Some(vec![TOPIC_PLAYER_1]);
+            return Some(vec![TOPIC_PLAYER_1.to_string()]);
         }
         if self.id == 2 {
-            return Some(vec![TOPIC_PLAYER_2]);
+            return Some(vec![TOPIC_PLAYER_2.to_string()]);
         }
         None
     }

--- a/examples/basic_game_events/player.rs
+++ b/examples/basic_game_events/player.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::Commands, topic_ids::TopicIds,
-};
+use crate::{commands::Commands, topic_ids::TopicIds};
 use pubsub_bus::*;
 
 pub struct Player {
@@ -12,16 +10,16 @@ impl Subscriber<Commands, TopicIds> for Player {
         let event_id = event.get_id();
         let event_source_id = event.get_source_id();
         match event.get_content() {
-            Commands::Move { player_id, x, y } => {
+            Commands::Move { dx, dy } => {
                 println!(
-                    "[Player {}] Received event {} from {}: Move({}, {}, {})",
-                    self.id, event_id, event_source_id, player_id, x, y
+                    "[Player {}] Received event {} from ID{}: Move({}, {})",
+                    self.id, event_id, event_source_id, dx, dy
                 );
             }
-            Commands::Atack { player_id } => {
+            Commands::Atack => {
                 println!(
-                    "[Player {}] Received event {} from {}: Atack({})",
-                    self.id, event_id, event_source_id, player_id
+                    "[Player {}] Received event {} from ID{}: Atack",
+                    self.id, event_id, event_source_id
                 );
             }
         }

--- a/examples/basic_game_events/topic_ids.rs
+++ b/examples/basic_game_events/topic_ids.rs
@@ -1,2 +1,2 @@
-pub const TOPIC_PLAYER_1: u32 = 1;
-pub const TOPIC_PLAYER_2: u32 = 2;
+pub const TOPIC_PLAYER_1: &str = "player_1";
+pub const TOPIC_PLAYER_2: &str = "player_2";

--- a/examples/basic_game_events/topic_ids.rs
+++ b/examples/basic_game_events/topic_ids.rs
@@ -1,2 +1,7 @@
-pub const TOPIC_PLAYER_1: &str = "player_1";
-pub const TOPIC_PLAYER_2: &str = "player_2";
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TopicIds {
+    Player1,
+    Player2,
+}

--- a/examples/basic_game_events/topic_ids.rs
+++ b/examples/basic_game_events/topic_ids.rs
@@ -1,0 +1,2 @@
+pub const TOPIC_PLAYER_1: u32 = 1;
+pub const TOPIC_PLAYER_2: u32 = 2;

--- a/examples/basic_game_events/topic_ids.rs
+++ b/examples/basic_game_events/topic_ids.rs
@@ -1,6 +1,6 @@
 
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(PartialEq)]
 pub enum TopicIds {
     Player1,
     Player2,

--- a/examples/basic_game_events/topic_ids.rs
+++ b/examples/basic_game_events/topic_ids.rs
@@ -1,5 +1,3 @@
-
-
 #[derive(PartialEq)]
 pub enum TopicIds {
     Player1,

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -17,8 +17,9 @@ mod tests;
 
 pub struct EventBus<ContentType> {
     next_event_id: Arc<Mutex<u64>>,
-    // RwLock is we do not expect many writes, but many reads
+    // RwLock as we do not expect many writes, but many reads
     subscribers: RwLock<Vec<Arc<Mutex<dyn Subscriber<ContentType>>>>>,
+    //Topics: RwLock<HashMap<u32, Vec<u32>>>, // topic_id, subscriber_id 
 }
 
 impl<ContentType> EventBus<ContentType> {
@@ -43,10 +44,18 @@ impl<ContentType> EventBus<ContentType> {
         *id
     }
 
-    pub fn publish(&self, event: &mut Event<ContentType>) {
+    pub fn publish(&self, event: &mut Event<ContentType>, topic_id: Option<u32>) {
         // reserve a new id for the event
         let id = self.get_next_id();
         event.set_id(id);
+        
+        // set the topic id
+        if topic_id == Some(0) {
+            println!("Topic id 0 is the same as no topic id. Use None instead.");
+        }
+        if let Some(topic_id) = topic_id {
+            event.set_topic_id(topic_id);
+        }
 
         // notify all subscribers
         for s in self.subscribers.read().unwrap().iter() {

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -19,26 +19,32 @@ pub struct EventBus<ContentType, TopicId: std::cmp::PartialEq> {
     internal: Arc<EventBusInternal<ContentType, TopicId>>,
 }
 
-impl <ContentType, TopicId: std::cmp::PartialEq> EventBus<ContentType, TopicId> {
+impl<ContentType, TopicId: std::cmp::PartialEq> EventBus<ContentType, TopicId> {
     pub fn new() -> Self {
         Self {
             internal: Arc::new(EventBusInternal::new()),
         }
     }
 
-    pub fn add_subscriber(&self, subscriber: Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>) {
+    pub fn add_subscriber_shared(&self, subscriber: Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>) {
+        self.internal.add_subscriber_shared(subscriber);
+    }
+
+    pub fn add_subscriber<S>(&self, subscriber: S)
+    where
+        S: Subscriber<ContentType, TopicId> + 'static, // Ensures it can be converted to a trait object
+    {
         self.internal.add_subscriber(subscriber);
     }
 
-    
     pub fn add_publisher(&self, publisher: &mut dyn Publisher<ContentType, TopicId>) {
         publisher.get_mut_emitter().set_bus(self);
     }
-    
+
     pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>) {
         self.internal.publish(event, topic_id);
     }
-    
+
     pub fn get_internal(&self) -> Arc<EventBusInternal<ContentType, TopicId>> {
         self.internal.clone()
     }
@@ -46,6 +52,7 @@ impl <ContentType, TopicId: std::cmp::PartialEq> EventBus<ContentType, TopicId> 
 
 pub struct EventBusInternal<ContentType, TopicId: std::cmp::PartialEq> {
     next_event_id: Arc<Mutex<usize>>,
+    
     // RwLock as we do not expect many writes, but many reads
     subscribers: RwLock<Vec<Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>>>,
 }
@@ -58,10 +65,22 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventBusInternal<ContentType, To
         }
     }
 
-    pub fn add_subscriber(&self, subscriber: Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>) {
+    pub fn add_subscriber_shared(
+        &self,
+        subscriber: Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>,
+    ) {
         self.subscribers.write().unwrap().push(subscriber);
     }
 
+    // Accepts any object implementing Subscriber and wraps it in Arc + Mutex
+    pub fn add_subscriber<S>(&self, subscriber: S)
+    where
+        S: Subscriber<ContentType, TopicId> + 'static, // Ensures it can be converted to a trait object
+    {
+        let subscriber = Arc::new(Mutex::new(subscriber));
+
+        self.subscribers.write().unwrap().push(subscriber);
+    }
 
     pub fn get_next_id(&self) -> usize {
         let mut id = self.next_event_id.lock().unwrap();
@@ -72,10 +91,10 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventBusInternal<ContentType, To
     pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>) {
         // reserve a new id for the event
         let id = self.get_next_id();
-        
+
         let mut event_internal = BusEvent::new(event, topic_id);
         event_internal.set_id(id);
-        
+
         // notify all subscribers
         for s in self.subscribers.read().unwrap().iter() {
             // if there are topics

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -1,46 +1,46 @@
-// use crate::{Event, EventBus, IntoEvent, Subscriber};
-// use std::sync::{Arc, Mutex};
+use crate::{BusEvent, EventBus, Subscriber};
+use std::sync::{Arc, Mutex};
 
-// struct TestEvent {
-//     destination: u64,
-//     value: i32,
-// }
+struct TestEvent {
+    destination: u64,
+    value: i32,
+}
 
-// struct TestSubscriber {
-//     id: u64,
-// }
+struct TestSubscriber {
+    id: u64,
+}
 
-// impl Subscriber<TestEvent> for TestSubscriber {
-//     fn on_event(&mut self, event: &Event<TestEvent>) {
-//         let content = event.get_content();
-//         if content.destination != self.id {
-//             return;
-//         }
-//         println!("Received event with content: {}", content.value);
-//     }
-// }
+impl Subscriber<TestEvent, u32> for TestSubscriber {
+    fn on_event(&mut self, event: &BusEvent<TestEvent, u32>) {
+        let content = event.get_content();
+        if content.destination != self.id {
+            return;
+        }
+        println!("Received event with content: {}", content.value);
+    }
+}
 
-// #[test]
-// fn test_bus() {
-//     // Create a bus and subscribers
-//     let bus = EventBus::new();
+#[test]
+fn test_bus() {
+    // Create a bus and subscribers
+    let bus = EventBus::new();
 
-//     let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
-//     let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
+    let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
+    let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
 
-//     bus.add_subscriber(subscriber1);
-//     bus.add_subscriber(subscriber2);
+    bus.add_subscriber(subscriber1);
+    bus.add_subscriber(subscriber2);
 
-//     // Create and publish events
-//     let event42 = TestEvent {
-//         destination: 1,
-//         value: 42,
-//     };
-//     let event24 = TestEvent {
-//         destination: 2,
-//         value: 24,
-//     };
+    // Create and publish events
+    let event42 = TestEvent {
+        destination: 1,
+        value: 42,
+    };
+    let event24 = TestEvent {
+        destination: 2,
+        value: 24,
+    };
 
-//     bus.publish(&mut event42.into_event(), None);
-//     bus.publish(&mut event24.into_event(), None);
-// }
+    bus.publish(event42, None);
+    bus.publish(event24, None);
+}

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -27,9 +27,12 @@ fn test_bus() {
 
     let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
     let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
+    let subscriber4 = TestSubscriber { id: 4 };
 
-    bus.add_subscriber(subscriber1);
-    bus.add_subscriber(subscriber2);
+    bus.add_subscriber_shared(subscriber1);
+    bus.add_subscriber_shared(subscriber2);
+    bus.add_subscriber(subscriber4);
+    
 
     // Create and publish events
     let event42 = TestEvent {
@@ -40,7 +43,18 @@ fn test_bus() {
         destination: 2,
         value: 24,
     };
+    let event64 = TestEvent {
+        destination: 3,
+        value: 64,
+    };
+    
+    let event84 = TestEvent {
+        destination: 4,
+        value: 84,
+    };
 
     bus.publish(event42, None);
     bus.publish(event24, None);
+    bus.publish(event64, None);
+    bus.publish(event84, None);
 }

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -41,6 +41,6 @@ fn test_bus() {
         value: 24,
     };
 
-    bus.publish(&mut event42.into_event());
-    bus.publish(&mut event24.into_event());
+    bus.publish(&mut event42.into_event(), None);
+    bus.publish(&mut event24.into_event(), None);
 }

--- a/src/bus/tests.rs
+++ b/src/bus/tests.rs
@@ -1,46 +1,46 @@
-use crate::{Event, EventBus, IntoEvent, Subscriber};
-use std::sync::{Arc, Mutex};
+// use crate::{Event, EventBus, IntoEvent, Subscriber};
+// use std::sync::{Arc, Mutex};
 
-struct TestEvent {
-    destination: u64,
-    value: i32,
-}
+// struct TestEvent {
+//     destination: u64,
+//     value: i32,
+// }
 
-struct TestSubscriber {
-    id: u64,
-}
+// struct TestSubscriber {
+//     id: u64,
+// }
 
-impl Subscriber<TestEvent> for TestSubscriber {
-    fn on_event(&mut self, event: &Event<TestEvent>) {
-        let content = event.get_content();
-        if content.destination != self.id {
-            return;
-        }
-        println!("Received event with content: {}", content.value);
-    }
-}
+// impl Subscriber<TestEvent> for TestSubscriber {
+//     fn on_event(&mut self, event: &Event<TestEvent>) {
+//         let content = event.get_content();
+//         if content.destination != self.id {
+//             return;
+//         }
+//         println!("Received event with content: {}", content.value);
+//     }
+// }
 
-#[test]
-fn test_bus() {
-    // Create a bus and subscribers
-    let bus = EventBus::new();
+// #[test]
+// fn test_bus() {
+//     // Create a bus and subscribers
+//     let bus = EventBus::new();
 
-    let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
-    let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
+//     let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
+//     let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
 
-    bus.add_subscriber(subscriber1);
-    bus.add_subscriber(subscriber2);
+//     bus.add_subscriber(subscriber1);
+//     bus.add_subscriber(subscriber2);
 
-    // Create and publish events
-    let event42 = TestEvent {
-        destination: 1,
-        value: 42,
-    };
-    let event24 = TestEvent {
-        destination: 2,
-        value: 24,
-    };
+//     // Create and publish events
+//     let event42 = TestEvent {
+//         destination: 1,
+//         value: 42,
+//     };
+//     let event24 = TestEvent {
+//         destination: 2,
+//         value: 24,
+//     };
 
-    bus.publish(&mut event42.into_event(), None);
-    bus.publish(&mut event24.into_event(), None);
-}
+//     bus.publish(&mut event42.into_event(), None);
+//     bus.publish(&mut event24.into_event(), None);
+// }

--- a/src/bus_event.rs
+++ b/src/bus_event.rs
@@ -14,7 +14,7 @@
 mod tests;
 
 /// A struct that represents an event that can be sent over the event bus.
-/// The content is user-defined. Besudes the content, the event has an id, 
+/// The content is user-defined. Besudes the content, the event has an id,
 /// a source id, and a topic id.
 pub struct BusEvent<ContentType, TopicId> {
     id: usize,
@@ -24,26 +24,17 @@ pub struct BusEvent<ContentType, TopicId> {
 }
 
 impl<ContentType, TopicId> BusEvent<ContentType, TopicId> {
-    pub fn new(content: ContentType, topic_id: Option<TopicId>) -> Self {
+    pub fn new(id: usize, source_id: u64, topic_id: Option<TopicId>, content: ContentType) -> Self {
         BusEvent {
-            id: 0,
+            id,
             topic_id,
-            source_id: 0,
+            source_id,
             content,
         }
     }
 
-    pub fn set_header(&mut self, id: usize, source_id: u64) {
-        self.id = id;
-        self.source_id = source_id;
-    }
-
     pub fn get_topic_id(&self) -> &Option<TopicId> {
         &self.topic_id
-    }
-
-    pub fn set_topic_id(&mut self, topic_id: Option<TopicId>) {
-        self.topic_id = topic_id;
     }
 
     pub fn get_id(&self) -> usize {
@@ -60,19 +51,5 @@ impl<ContentType, TopicId> BusEvent<ContentType, TopicId> {
 
     pub fn get_mut_content(&mut self) -> &mut ContentType {
         &mut self.content
-    }
-
-    pub fn set_id(&mut self, id: usize) {
-        self.id = id;
-    }
-}
-
-pub trait IntoEvent<ContentType, TopicId> {
-    fn into_event(self, topic: Option<TopicId>) -> BusEvent<ContentType, TopicId>;
-}
-
-impl<ContentType, TopicId> IntoEvent<ContentType, TopicId> for ContentType {
-    fn into_event(self, topic: Option<TopicId>) -> BusEvent<ContentType, TopicId> {
-        BusEvent::new(self, topic)
     }
 }

--- a/src/bus_event.rs
+++ b/src/bus_event.rs
@@ -9,19 +9,20 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
+
 #[cfg(test)]
 mod tests;
 
-pub struct Event<ContentType, TopicId> {
+pub struct BusEvent<ContentType, TopicId> {
     id: usize,
     topic_id: Option<TopicId>,
     source_id: u64,
     content: ContentType,
 }
 
-impl<ContentType, TopicId> Event<ContentType, TopicId> {
+impl<ContentType, TopicId> BusEvent<ContentType, TopicId> {
     pub fn new(content: ContentType, topic_id: Option<TopicId>) -> Self {
-        Event {
+        BusEvent {
             id: 0,
             topic_id,
             source_id: 0,
@@ -64,11 +65,11 @@ impl<ContentType, TopicId> Event<ContentType, TopicId> {
 }
 
 pub trait IntoEvent<ContentType, TopicId> {
-    fn into_event(self, topic: Option<TopicId>) -> Event<ContentType, TopicId>;
+    fn into_event(self, topic: Option<TopicId>) -> BusEvent<ContentType, TopicId>;
 }
 
 impl<ContentType, TopicId> IntoEvent<ContentType, TopicId> for ContentType {
-    fn into_event(self, topic: Option<TopicId>) -> Event<ContentType, TopicId> {
-        Event::new(self, topic)
+    fn into_event(self, topic: Option<TopicId>) -> BusEvent<ContentType, TopicId> {
+        BusEvent::new(self, topic)
     }
 }

--- a/src/bus_event.rs
+++ b/src/bus_event.rs
@@ -13,6 +13,9 @@
 #[cfg(test)]
 mod tests;
 
+/// A struct that represents an event that can be sent over the event bus.
+/// The content is user-defined. Besudes the content, the event has an id, 
+/// a source id, and a topic id.
 pub struct BusEvent<ContentType, TopicId> {
     id: usize,
     topic_id: Option<TopicId>,

--- a/src/bus_event/tests.rs
+++ b/src/bus_event/tests.rs
@@ -6,7 +6,7 @@ struct TestEvent {
 
 #[test]
 fn test_event() {
-    let mut event1 = BusEvent::new(TestEvent { a: 42 }, Some(1));
+    let mut event1 = BusEvent::new(1, 2, Some(1), TestEvent { a: 42 });
 
     assert_eq!(event1.get_content().a, 42);
 
@@ -14,17 +14,15 @@ fn test_event() {
     content.a = 43;
     assert_eq!(event1.get_content().a, 43);
 
-    event1.set_header(1, 2);
     assert_eq!(event1.get_id(), 1);
     assert_eq!(event1.get_source_id(), 2);
 
-    let mut event2: BusEvent<TestEvent, u32> = BusEvent::new(TestEvent { a: 24 }, None);
+    let event2: BusEvent<TestEvent, u32> = BusEvent::new(2, 3, None, TestEvent { a: 24 });
     assert_eq!(event2.get_content().a, 24);
 
     assert_eq!(*event2.get_topic_id(), None);
     assert_eq!(event2.get_content().a, 24);
 
-    event2.set_header(2, 3);
     assert_eq!(event2.get_id(), 2);
     assert_eq!(event2.get_source_id(), 3);
 }

--- a/src/bus_event/tests.rs
+++ b/src/bus_event/tests.rs
@@ -1,4 +1,4 @@
-use crate::Event;
+use crate::BusEvent;
 
 struct TestEvent {
     a: i32,
@@ -6,9 +6,7 @@ struct TestEvent {
 
 #[test]
 fn test_event() {
-    use crate::event::IntoEvent;
-
-    let mut event1 = TestEvent { a: 42 }.into_event(Some(1));
+    let mut event1 = BusEvent::new(TestEvent { a: 42 }, Some(1));
 
     assert_eq!(event1.get_content().a, 42);
 
@@ -19,17 +17,14 @@ fn test_event() {
     event1.set_header(1, 2);
     assert_eq!(event1.get_id(), 1);
     assert_eq!(event1.get_source_id(), 2);
-    
-    let mut event2: Event<TestEvent, u32> = TestEvent { a: 24 }.into_event(None);
+
+    let mut event2: BusEvent<TestEvent, u32> = BusEvent::new(TestEvent { a: 24 }, None);
     assert_eq!(event2.get_content().a, 24);
-    
+
     assert_eq!(*event2.get_topic_id(), None);
     assert_eq!(event2.get_content().a, 24);
-    
+
     event2.set_header(2, 3);
     assert_eq!(event2.get_id(), 2);
     assert_eq!(event2.get_source_id(), 3);
-
-    
-    
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -12,18 +12,18 @@
 #[cfg(test)]
 mod tests;
 
-pub struct Event<ContentType> {
+pub struct Event<ContentType, TopicId> {
     id: usize,
-    topic_id: u32,
+    topic_id: Option<TopicId>,
     source_id: u64,
     content: ContentType,
 }
 
-impl<ContentType> Event<ContentType> {
-    pub fn new(content: ContentType) -> Self {
+impl<ContentType, TopicId> Event<ContentType, TopicId> {
+    pub fn new(content: ContentType, topic_id: Option<TopicId>) -> Self {
         Event {
             id: 0,
-            topic_id: 0,
+            topic_id,
             source_id: 0,
             content,
         }
@@ -34,11 +34,11 @@ impl<ContentType> Event<ContentType> {
         self.source_id = source_id;
     }
 
-    pub fn get_topic_id(&self) -> u32 {
-        self.topic_id
+    pub fn get_topic_id(&self) -> &Option<TopicId> {
+        &self.topic_id
     }
 
-    pub fn set_topic_id(&mut self, topic_id: u32) {
+    pub fn set_topic_id(&mut self, topic_id: Option<TopicId>) {
         self.topic_id = topic_id;
     }
 
@@ -63,12 +63,12 @@ impl<ContentType> Event<ContentType> {
     }
 }
 
-pub trait IntoEvent<ContentType> {
-    fn into_event(self) -> Event<ContentType>;
+pub trait IntoEvent<ContentType, TopicId> {
+    fn into_event(self, topic: Option<TopicId>) -> Event<ContentType, TopicId>;
 }
 
-impl<ContentType> IntoEvent<ContentType> for ContentType {
-    fn into_event(self) -> Event<ContentType> {
-        Event::new(self)
+impl<ContentType, TopicId> IntoEvent<ContentType, TopicId> for ContentType {
+    fn into_event(self, topic: Option<TopicId>) -> Event<ContentType, TopicId> {
+        Event::new(self, topic)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -13,7 +13,7 @@
 mod tests;
 
 pub struct Event<ContentType> {
-    id: u64,
+    id: usize,
     topic_id: u32,
     source_id: u64,
     content: ContentType,
@@ -29,20 +29,20 @@ impl<ContentType> Event<ContentType> {
         }
     }
 
-    pub fn set_header(&mut self, id: u64, source_id: u64) {
+    pub fn set_header(&mut self, id: usize, source_id: u64) {
         self.id = id;
         self.source_id = source_id;
     }
-    
+
     pub fn get_topic_id(&self) -> u32 {
         self.topic_id
     }
-    
+
     pub fn set_topic_id(&mut self, topic_id: u32) {
         self.topic_id = topic_id;
     }
 
-    pub fn get_id(&self) -> u64 {
+    pub fn get_id(&self) -> usize {
         self.id
     }
 
@@ -58,7 +58,7 @@ impl<ContentType> Event<ContentType> {
         &mut self.content
     }
 
-    pub fn set_id(&mut self, id: u64) {
+    pub fn set_id(&mut self, id: usize) {
         self.id = id;
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,6 +14,7 @@ mod tests;
 
 pub struct Event<ContentType> {
     id: u64,
+    topic_id: u32,
     source_id: u64,
     content: ContentType,
 }
@@ -22,6 +23,7 @@ impl<ContentType> Event<ContentType> {
     pub fn new(content: ContentType) -> Self {
         Event {
             id: 0,
+            topic_id: 0,
             source_id: 0,
             content,
         }
@@ -30,6 +32,14 @@ impl<ContentType> Event<ContentType> {
     pub fn set_header(&mut self, id: u64, source_id: u64) {
         self.id = id;
         self.source_id = source_id;
+    }
+    
+    pub fn get_topic_id(&self) -> u32 {
+        self.topic_id
+    }
+    
+    pub fn set_topic_id(&mut self, topic_id: u32) {
+        self.topic_id = topic_id;
     }
 
     pub fn get_id(&self) -> u64 {

--- a/src/event/tests.rs
+++ b/src/event/tests.rs
@@ -1,3 +1,4 @@
+use crate::Event;
 
 struct TestEvent {
     a: i32,
@@ -7,15 +8,28 @@ struct TestEvent {
 fn test_event() {
     use crate::event::IntoEvent;
 
-    let mut event = TestEvent { a: 42 }.into_event();
+    let mut event1 = TestEvent { a: 42 }.into_event(Some(1));
 
-    assert_eq!(event.get_content().a, 42);
+    assert_eq!(event1.get_content().a, 42);
 
-    let content = event.get_mut_content();
+    let content = event1.get_mut_content();
     content.a = 43;
-    assert_eq!(event.get_content().a, 43);
+    assert_eq!(event1.get_content().a, 43);
 
-    event.set_header(1, 2);
-    assert_eq!(event.get_id(), 1);
-    assert_eq!(event.get_source_id(), 2);
+    event1.set_header(1, 2);
+    assert_eq!(event1.get_id(), 1);
+    assert_eq!(event1.get_source_id(), 2);
+    
+    let mut event2: Event<TestEvent, u32> = TestEvent { a: 24 }.into_event(None);
+    assert_eq!(event2.get_content().a, 24);
+    
+    assert_eq!(*event2.get_topic_id(), None);
+    assert_eq!(event2.get_content().a, 24);
+    
+    event2.set_header(2, 3);
+    assert_eq!(event2.get_id(), 2);
+    assert_eq!(event2.get_source_id(), 3);
+
+    
+    
 }

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 #[cfg(test)]
 mod tests;
 
+/// The Event Bus itself. Add subscribers and publishers to it.
 pub struct EventBus<ContentType, TopicId: std::cmp::PartialEq> {
     internal: Arc<EventBusInternal<ContentType, TopicId>>,
 }

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -1,0 +1,60 @@
+// *************************************************************************
+//
+// Copyright (c) 2025 Andrei Gramakov. All rights reserved.
+//
+// This file is licensed under the terms of the MIT license.
+// For a copy, see: https://opensource.org/licenses/MIT
+//
+// site:    https://agramakov.me
+// e-mail:  mail@agramakov.me
+//
+// *************************************************************************
+use crate::{event_bus_internal::EventBusInternal, Publisher, Subscriber};
+use std::sync::{Arc, Mutex};
+
+#[cfg(test)]
+mod tests;
+
+pub struct EventBus<ContentType, TopicId: std::cmp::PartialEq> {
+    internal: Arc<EventBusInternal<ContentType, TopicId>>,
+}
+
+impl<ContentType, TopicId: std::cmp::PartialEq> EventBus<ContentType, TopicId> {
+    pub fn new() -> Self {
+        Self {
+            internal: Arc::new(EventBusInternal::new()),
+        }
+    }
+
+    pub fn add_subscriber_shared(
+        &self,
+        subscriber: Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>,
+    ) {
+        self.internal.add_subscriber_shared(subscriber);
+    }
+
+    pub fn add_subscriber<S>(&self, subscriber: S)
+    where
+        S: Subscriber<ContentType, TopicId> + 'static, // Ensures it can be converted to a trait object
+    {
+        self.internal.add_subscriber(subscriber);
+    }
+
+    /// Add a publisher to the event bus.
+    /// If source_id is None, the publisher will be assigned a unique id.
+    pub fn add_publisher(
+        &self,
+        publisher: &mut dyn Publisher<ContentType, TopicId>,
+        source_id: Option<u64>,
+    ) -> Result<(), &'static str> {
+        publisher.get_mut_emitter().set_bus(self, source_id)
+    }
+
+    pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>, source_id: u64) {
+        self.internal.publish(event, topic_id, source_id);
+    }
+
+    pub fn get_internal(&self) -> Arc<EventBusInternal<ContentType, TopicId>> {
+        self.internal.clone()
+    }
+}

--- a/src/event_bus/tests.rs
+++ b/src/event_bus/tests.rs
@@ -53,8 +53,8 @@ fn test_bus() {
         value: 84,
     };
 
-    bus.publish(event42, None);
-    bus.publish(event24, None);
-    bus.publish(event64, None);
-    bus.publish(event84, None);
+    bus.publish(event42, None, 0);
+    bus.publish(event24, None, 0);
+    bus.publish(event64, None, 0);
+    bus.publish(event84, None, 0);
 }

--- a/src/event_bus_internal.rs
+++ b/src/event_bus_internal.rs
@@ -81,11 +81,8 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventBusInternal<ContentType, To
     }
 
     pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>, source_id: u64) {
-        // reserve a new id for the event
-        let id = self.get_next_id();
-
-        let mut event_internal = BusEvent::new(event, topic_id);
-        event_internal.set_header(id, source_id);
+        let id = self.get_next_id(); // reserve a new id for the event
+        let event_internal = BusEvent::new(id, source_id, topic_id, event);
 
         // notify all subscribers
         for s in self.subscribers.read().unwrap().iter() {

--- a/src/event_bus_internal.rs
+++ b/src/event_bus_internal.rs
@@ -9,52 +9,19 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
-use super::{BusEvent, Publisher, Subscriber};
+
 use std::sync::{Arc, Mutex, RwLock};
 
-#[cfg(test)]
-mod tests;
-
-pub struct EventBus<ContentType, TopicId: std::cmp::PartialEq> {
-    internal: Arc<EventBusInternal<ContentType, TopicId>>,
-}
-
-impl<ContentType, TopicId: std::cmp::PartialEq> EventBus<ContentType, TopicId> {
-    pub fn new() -> Self {
-        Self {
-            internal: Arc::new(EventBusInternal::new()),
-        }
-    }
-
-    pub fn add_subscriber_shared(&self, subscriber: Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>) {
-        self.internal.add_subscriber_shared(subscriber);
-    }
-
-    pub fn add_subscriber<S>(&self, subscriber: S)
-    where
-        S: Subscriber<ContentType, TopicId> + 'static, // Ensures it can be converted to a trait object
-    {
-        self.internal.add_subscriber(subscriber);
-    }
-
-    pub fn add_publisher(&self, publisher: &mut dyn Publisher<ContentType, TopicId>) {
-        publisher.get_mut_emitter().set_bus(self);
-    }
-
-    pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>) {
-        self.internal.publish(event, topic_id);
-    }
-
-    pub fn get_internal(&self) -> Arc<EventBusInternal<ContentType, TopicId>> {
-        self.internal.clone()
-    }
-}
+use crate::{BusEvent, Subscriber};
 
 pub struct EventBusInternal<ContentType, TopicId: std::cmp::PartialEq> {
     next_event_id: Arc<Mutex<usize>>,
-    
+
     // RwLock as we do not expect many writes, but many reads
     subscribers: RwLock<Vec<Arc<Mutex<dyn Subscriber<ContentType, TopicId>>>>>,
+
+    // Publisher IDs
+    publishers: RwLock<Vec<u64>>,
 }
 
 impl<ContentType, TopicId: std::cmp::PartialEq> EventBusInternal<ContentType, TopicId> {
@@ -62,6 +29,7 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventBusInternal<ContentType, To
         Self {
             next_event_id: Arc::new(Mutex::new(0)),
             subscribers: RwLock::new(Vec::new()),
+            publishers: RwLock::new(Vec::new()),
         }
     }
 
@@ -82,18 +50,42 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventBusInternal<ContentType, To
         self.subscribers.write().unwrap().push(subscriber);
     }
 
+    pub fn register_publisher(&self, source_id: Option<u64>) -> Result<u64, &'static str> {
+        let mut publishers = self.publishers.write().unwrap();
+        let id = match source_id {
+            // If the source_id is provided, check if it already exists
+            Some(id) => {
+                if publishers.contains(&id) {
+                    return Err("Publisher with the same id already exists");
+                }
+                id
+            }
+            // If the source_id is not provided, assign a new id in sequence
+            None => {
+                let mut id = 0;
+                while publishers.contains(&id) {
+                    id += 1;
+                }
+                id
+            }
+        };
+
+        publishers.push(id);
+        Ok(id)
+    }
+
     pub fn get_next_id(&self) -> usize {
         let mut id = self.next_event_id.lock().unwrap();
         *id += 1;
         *id
     }
 
-    pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>) {
+    pub fn publish(&self, event: ContentType, topic_id: Option<TopicId>, source_id: u64) {
         // reserve a new id for the event
         let id = self.get_next_id();
 
         let mut event_internal = BusEvent::new(event, topic_id);
-        event_internal.set_id(id);
+        event_internal.set_header(id, source_id);
 
         // notify all subscribers
         for s in self.subscribers.read().unwrap().iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 //
 // *************************************************************************
 mod bus;
-mod event;
+mod bus_event;
 mod publisher;
 mod subscriber;
 pub use bus::EventBus;
-pub use event::{Event, IntoEvent};
+pub use bus_event::BusEvent;
 pub use publisher::{EventEmitter, Publisher};
 pub use subscriber::Subscriber;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod event_bus_internal;
 mod bus_event;
 mod publisher;
 mod subscriber;
+
 pub use event_bus::EventBus;
 pub use bus_event::BusEvent;
 pub use publisher::{EventEmitter, Publisher};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,12 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
-mod bus;
+mod event_bus;
+mod event_bus_internal;
 mod bus_event;
 mod publisher;
 mod subscriber;
-pub use bus::EventBus;
+pub use event_bus::EventBus;
 pub use bus_event::BusEvent;
 pub use publisher::{EventEmitter, Publisher};
 pub use subscriber::Subscriber;

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -9,7 +9,6 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
-use crate::event::IntoEvent;
 use crate::EventBus;
 use std::sync::Arc;
 
@@ -37,13 +36,12 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicI
 
     pub fn publish(&mut self, content: ContentType, topic_id: Option<TopicId>) {
         
-        let mut event = content.into_event(topic_id);
         match &mut self.event_bus {
             None => {
                 panic!("Publisher has no bus");
             }
             Some(bus) => {
-                bus.publish(&mut event, topic_id);
+                bus.publish(content, topic_id);
             }
         }
     }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -52,10 +52,8 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicI
         Ok(())
     }
 
-    pub fn set_source_id(&mut self, source_id: u64) {
-        self.source_id = source_id;
-    }
-
+    /// Publish an event to the event bus.
+    /// If topic_id is None, the event will be sent to all subscribers.
     pub fn publish(&mut self, content: ContentType, topic_id: Option<TopicId>) {
         match &mut self.event_bus {
             None => {
@@ -71,5 +69,12 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicI
 /// Publisher is a trait that defines a publisher to the event bus.
 /// Publisher is expected to care an EventEmitter.
 pub trait Publisher<ContentType, TopicId: std::cmp::PartialEq> {
+    /// Get the emitter of the publisher. Has to be implemented by the publisher.
     fn get_mut_emitter(&mut self) -> &mut EventEmitter<ContentType, TopicId>;
+
+    /// Default implementation to Publish an event to the event bus.
+    /// If topic_id is None, the event will be sent to all subscribers.
+    fn publish(&mut self, content: ContentType, topic_id: Option<TopicId>) {
+        self.get_mut_emitter().publish(content, topic_id);
+    }
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -16,12 +16,12 @@ use std::sync::Arc;
 #[cfg(test)]
 mod tests;
 
-pub struct EventEmitter<ContentType> {
-    event_bus: Option<Arc<EventBus<ContentType>>>,
+pub struct EventEmitter<ContentType, TopicId: std::cmp::PartialEq> {
+    event_bus: Option<Arc<EventBus<ContentType, TopicId>>>,
 }
 
-impl<ContentType> EventEmitter<ContentType> {
-    pub fn with_bus(bus: Arc<EventBus<ContentType>>) -> Self {
+impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicId> {
+    pub fn with_bus(bus: Arc<EventBus<ContentType, TopicId>>) -> Self {
         Self {
             event_bus: Some(bus),
         }
@@ -31,12 +31,13 @@ impl<ContentType> EventEmitter<ContentType> {
         Self { event_bus: None }
     }
 
-    pub fn set_bus(&mut self, bus: Arc<EventBus<ContentType>>) {
+    pub fn set_bus(&mut self, bus: Arc<EventBus<ContentType, TopicId>>) {
         self.event_bus = Some(bus);
     }
 
-    pub fn publish(&mut self, content: ContentType, topic_id: Option<u32>) {
-        let mut event = content.into_event();
+    pub fn publish(&mut self, content: ContentType, topic_id: Option<TopicId>) {
+        
+        let mut event = content.into_event(topic_id);
         match &mut self.event_bus {
             None => {
                 panic!("Publisher has no bus");
@@ -48,6 +49,6 @@ impl<ContentType> EventEmitter<ContentType> {
     }
 }
 
-pub trait Publisher<ContentType> {
-    fn get_mut_emitter(&mut self) -> &mut EventEmitter<ContentType>;
+pub trait Publisher<ContentType, TopicId: std::cmp::PartialEq> {
+    fn get_mut_emitter(&mut self) -> &mut EventEmitter<ContentType, TopicId>;
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -35,14 +35,14 @@ impl<ContentType> EventEmitter<ContentType> {
         self.event_bus = Some(bus);
     }
 
-    pub fn publish(&mut self, content: ContentType) {
+    pub fn publish(&mut self, content: ContentType, topic_id: Option<u32>) {
         let mut event = content.into_event();
         match &mut self.event_bus {
             None => {
                 panic!("Publisher has no bus");
             }
             Some(bus) => {
-                bus.publish(&mut event);
+                bus.publish(&mut event, topic_id);
             }
         }
     }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -9,6 +9,7 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
+use crate::bus::EventBusInternal;
 use crate::EventBus;
 use std::sync::Arc;
 
@@ -16,13 +17,13 @@ use std::sync::Arc;
 mod tests;
 
 pub struct EventEmitter<ContentType, TopicId: std::cmp::PartialEq> {
-    event_bus: Option<Arc<EventBus<ContentType, TopicId>>>,
+    event_bus: Option<Arc<EventBusInternal<ContentType, TopicId>>>,
 }
 
 impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicId> {
-    pub fn with_bus(bus: Arc<EventBus<ContentType, TopicId>>) -> Self {
+    pub fn with_bus(bus: &EventBus<ContentType, TopicId>) -> Self {
         Self {
-            event_bus: Some(bus),
+            event_bus: Some(bus.get_internal()),
         }
     }
 
@@ -30,12 +31,11 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicI
         Self { event_bus: None }
     }
 
-    pub fn set_bus(&mut self, bus: Arc<EventBus<ContentType, TopicId>>) {
-        self.event_bus = Some(bus);
+    pub fn set_bus(&mut self, bus: &EventBus<ContentType, TopicId>) {
+        self.event_bus = Some(bus.get_internal());
     }
 
     pub fn publish(&mut self, content: ContentType, topic_id: Option<TopicId>) {
-        
         match &mut self.event_bus {
             None => {
                 panic!("Publisher has no bus");

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -9,30 +9,51 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
-use crate::bus::EventBusInternal;
-use crate::EventBus;
+use crate::{event_bus_internal::EventBusInternal, EventBus};
 use std::sync::Arc;
 
 #[cfg(test)]
 mod tests;
 
+/// EventEmitter is a struct that can be used to publish events to the event bus.
+/// It supposed to be used by the publisher.
 pub struct EventEmitter<ContentType, TopicId: std::cmp::PartialEq> {
     event_bus: Option<Arc<EventBusInternal<ContentType, TopicId>>>,
+    source_id: u64,
 }
 
 impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicId> {
     pub fn with_bus(bus: &EventBus<ContentType, TopicId>) -> Self {
         Self {
             event_bus: Some(bus.get_internal()),
+            source_id: 0,
         }
     }
 
     pub fn new() -> Self {
-        Self { event_bus: None }
+        Self {
+            event_bus: None,
+            source_id: 0,
+        }
     }
 
-    pub fn set_bus(&mut self, bus: &EventBus<ContentType, TopicId>) {
+    /// Set the event bus for the emitter.
+    /// If source_id is None, the publisher will be assigned a unique id.
+    pub fn set_bus(
+        &mut self,
+        bus: &EventBus<ContentType, TopicId>,
+        source_id: Option<u64>,
+    ) -> Result<(), &'static str> {
+        let internal_bus = bus.get_internal();
+        let id = internal_bus.register_publisher(source_id)?;
+
+        self.source_id = id;
         self.event_bus = Some(bus.get_internal());
+        Ok(())
+    }
+
+    pub fn set_source_id(&mut self, source_id: u64) {
+        self.source_id = source_id;
     }
 
     pub fn publish(&mut self, content: ContentType, topic_id: Option<TopicId>) {
@@ -41,12 +62,14 @@ impl<ContentType, TopicId: std::cmp::PartialEq> EventEmitter<ContentType, TopicI
                 panic!("Publisher has no bus");
             }
             Some(bus) => {
-                bus.publish(content, topic_id);
+                bus.publish(content, topic_id, self.source_id);
             }
         }
     }
 }
 
+/// Publisher is a trait that defines a publisher to the event bus.
+/// Publisher is expected to care an EventEmitter.
 pub trait Publisher<ContentType, TopicId: std::cmp::PartialEq> {
     fn get_mut_emitter(&mut self) -> &mut EventEmitter<ContentType, TopicId>;
 }

--- a/src/publisher/tests.rs
+++ b/src/publisher/tests.rs
@@ -13,16 +13,17 @@ struct TestSubscriber {
 impl Subscriber<TestEvent, u32> for TestSubscriber {
     fn on_event(&mut self, event: &BusEvent<TestEvent, u32>) {
         let content = event.get_content();
+        let source = event.get_source_id();
         if content.destination != self.id {
             println!(
-                "Subscriber {} ignoring event with content: {}",
-                self.id, content.value
+                "Subscriber {} ignoring event from ID{} with content: {}",
+                self.id, source, content.value
             );
             return;
         }
         println!(
-            "Subscriber {} received event with content: {}",
-            self.id, content.value
+            "Subscriber {} received event from ID{} with content: {}",
+            self.id,  source, content.value
         );
     }
 }
@@ -70,8 +71,8 @@ fn test_bus() {
 
     bus.add_subscriber_shared(subscriber1);
     bus.add_subscriber_shared(subscriber2);
-    bus.add_publisher(&mut publisher1);
-    bus.add_publisher(&mut publisher2);
+    bus.add_publisher(&mut publisher1, None).unwrap();
+    bus.add_publisher(&mut publisher2, Some(2)).unwrap();
 
     publisher1.publish_to(0);
     publisher1.publish_to(1);

--- a/src/publisher/tests.rs
+++ b/src/publisher/tests.rs
@@ -60,7 +60,7 @@ impl Publisher<TestEvent, u32> for TestPublisher {
 #[test]
 fn test_bus() {
     // Create a bus and subscribers
-    let bus = Arc::new(EventBus::new());
+    let bus = EventBus::new();
 
     let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
     let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));

--- a/src/publisher/tests.rs
+++ b/src/publisher/tests.rs
@@ -1,78 +1,78 @@
-use crate::{Event, EventBus, EventEmitter, Publisher, Subscriber};
-use std::sync::{Arc, Mutex};
+// use crate::{Event, EventBus, EventEmitter, Publisher, Subscriber};
+// use std::sync::{Arc, Mutex};
 
-struct TestEvent {
-    destination: u64,
-    value: i32,
-}
+// struct TestEvent {
+//     destination: u64,
+//     value: i32,
+// }
 
-struct TestSubscriber {
-    id: u64,
-}
+// struct TestSubscriber {
+//     id: u64,
+// }
 
-impl Subscriber<TestEvent> for TestSubscriber {
-    fn on_event(&mut self, event: &Event<TestEvent>) {
-        let content = event.get_content();
-        if content.destination != self.id {
-            return;
-        }
-        println!("Received event with content: {}", content.value);
-    }
-}
+// impl Subscriber<TestEvent> for TestSubscriber {
+//     fn on_event(&mut self, event: &Event<TestEvent>) {
+//         let content = event.get_content();
+//         if content.destination != self.id {
+//             return;
+//         }
+//         println!("Received event with content: {}", content.value);
+//     }
+// }
 
-struct TestPublisher {
-    publisher_value: i32,
-    pub emitter: EventEmitter<TestEvent>,
-}
+// struct TestPublisher {
+//     publisher_value: i32,
+//     pub emitter: EventEmitter<TestEvent>,
+// }
 
-impl TestPublisher {
-    pub fn new(value: i32) -> Self {
-        let publisher = EventEmitter::new();
-        Self {
-            publisher_value: value,
-            emitter: publisher,
-        }
-    }
+// impl TestPublisher {
+//     pub fn new(value: i32) -> Self {
+//         let publisher = EventEmitter::new();
+//         Self {
+//             publisher_value: value,
+//             emitter: publisher,
+//         }
+//     }
 
-    pub fn publish_to(&mut self, destination: u64) {
-        let event = TestEvent {
-            destination,
-            value: self.publisher_value,
-        };
+//     pub fn publish_to(&mut self, destination: u64) {
+//         let event = TestEvent {
+//             destination,
+//             value: self.publisher_value,
+//         };
 
-        self.emitter.publish(event, None);
-    }
-}
+//         self.emitter.publish(event, None);
+//     }
+// }
 
-impl Publisher<TestEvent> for TestPublisher {
-    fn get_mut_emitter(&mut self) -> &mut EventEmitter<TestEvent> {
-        &mut self.emitter
-    }
-}
+// impl Publisher<TestEvent> for TestPublisher {
+//     fn get_mut_emitter(&mut self) -> &mut EventEmitter<TestEvent> {
+//         &mut self.emitter
+//     }
+// }
 
-#[test]
-fn test_bus() {
-    // Create a bus and subscribers
-    let bus = Arc::new(EventBus::new());
+// #[test]
+// fn test_bus() {
+//     // Create a bus and subscribers
+//     let bus = Arc::new(EventBus::new());
 
-    let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
-    let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
+//     let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
+//     let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
 
-    let mut publisher1 = TestPublisher::new(42);
-    let mut publisher2 = TestPublisher::new(24);
+//     let mut publisher1 = TestPublisher::new(42);
+//     let mut publisher2 = TestPublisher::new(24);
 
-    bus.add_subscriber(subscriber1);
-    bus.add_subscriber(subscriber2);
-    bus.add_publisher(&mut publisher1);
-    bus.add_publisher(&mut publisher2);
+//     bus.add_subscriber(subscriber1);
+//     bus.add_subscriber(subscriber2);
+//     bus.add_publisher(&mut publisher1);
+//     bus.add_publisher(&mut publisher2);
 
-    publisher1.publish_to(0);
-    publisher1.publish_to(1);
-    publisher1.publish_to(2);
-    publisher1.publish_to(3);
+//     publisher1.publish_to(0);
+//     publisher1.publish_to(1);
+//     publisher1.publish_to(2);
+//     publisher1.publish_to(3);
 
-    publisher2.publish_to(0);
-    publisher2.publish_to(1);
-    publisher2.publish_to(2);
-    publisher2.publish_to(3);
-}
+//     publisher2.publish_to(0);
+//     publisher2.publish_to(1);
+//     publisher2.publish_to(2);
+//     publisher2.publish_to(3);
+// }

--- a/src/publisher/tests.rs
+++ b/src/publisher/tests.rs
@@ -68,8 +68,8 @@ fn test_bus() {
     let mut publisher1 = TestPublisher::new(42);
     let mut publisher2 = TestPublisher::new(24);
 
-    bus.add_subscriber(subscriber1);
-    bus.add_subscriber(subscriber2);
+    bus.add_subscriber_shared(subscriber1);
+    bus.add_subscriber_shared(subscriber2);
     bus.add_publisher(&mut publisher1);
     bus.add_publisher(&mut publisher2);
 

--- a/src/publisher/tests.rs
+++ b/src/publisher/tests.rs
@@ -1,78 +1,85 @@
-// use crate::{Event, EventBus, EventEmitter, Publisher, Subscriber};
-// use std::sync::{Arc, Mutex};
+use crate::{BusEvent, EventBus, EventEmitter, Publisher, Subscriber};
+use std::sync::{Arc, Mutex};
 
-// struct TestEvent {
-//     destination: u64,
-//     value: i32,
-// }
+struct TestEvent {
+    destination: u64,
+    value: i32,
+}
 
-// struct TestSubscriber {
-//     id: u64,
-// }
+struct TestSubscriber {
+    id: u64,
+}
 
-// impl Subscriber<TestEvent> for TestSubscriber {
-//     fn on_event(&mut self, event: &Event<TestEvent>) {
-//         let content = event.get_content();
-//         if content.destination != self.id {
-//             return;
-//         }
-//         println!("Received event with content: {}", content.value);
-//     }
-// }
+impl Subscriber<TestEvent, u32> for TestSubscriber {
+    fn on_event(&mut self, event: &BusEvent<TestEvent, u32>) {
+        let content = event.get_content();
+        if content.destination != self.id {
+            println!(
+                "Subscriber {} ignoring event with content: {}",
+                self.id, content.value
+            );
+            return;
+        }
+        println!(
+            "Subscriber {} received event with content: {}",
+            self.id, content.value
+        );
+    }
+}
 
-// struct TestPublisher {
-//     publisher_value: i32,
-//     pub emitter: EventEmitter<TestEvent>,
-// }
+struct TestPublisher {
+    publisher_value: i32,
+    pub emitter: EventEmitter<TestEvent, u32>,
+}
 
-// impl TestPublisher {
-//     pub fn new(value: i32) -> Self {
-//         let publisher = EventEmitter::new();
-//         Self {
-//             publisher_value: value,
-//             emitter: publisher,
-//         }
-//     }
+impl TestPublisher {
+    pub fn new(value: i32) -> Self {
+        let publisher = EventEmitter::new();
+        Self {
+            publisher_value: value,
+            emitter: publisher,
+        }
+    }
 
-//     pub fn publish_to(&mut self, destination: u64) {
-//         let event = TestEvent {
-//             destination,
-//             value: self.publisher_value,
-//         };
+    pub fn publish_to(&mut self, destination: u64) {
+        let event = TestEvent {
+            destination,
+            value: self.publisher_value,
+        };
 
-//         self.emitter.publish(event, None);
-//     }
-// }
+        self.emitter.publish(event, None);
+    }
+}
 
-// impl Publisher<TestEvent> for TestPublisher {
-//     fn get_mut_emitter(&mut self) -> &mut EventEmitter<TestEvent> {
-//         &mut self.emitter
-//     }
-// }
+impl Publisher<TestEvent, u32> for TestPublisher {
+    fn get_mut_emitter(&mut self) -> &mut EventEmitter<TestEvent, u32> {
+        &mut self.emitter
+    }
+}
 
-// #[test]
-// fn test_bus() {
-//     // Create a bus and subscribers
-//     let bus = Arc::new(EventBus::new());
+#[test]
+fn test_bus() {
+    // Create a bus and subscribers
+    let bus = Arc::new(EventBus::new());
 
-//     let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
-//     let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
+    let subscriber1 = Arc::new(Mutex::new(TestSubscriber { id: 1 }));
+    let subscriber2 = Arc::new(Mutex::new(TestSubscriber { id: 2 }));
 
-//     let mut publisher1 = TestPublisher::new(42);
-//     let mut publisher2 = TestPublisher::new(24);
+    let mut publisher1 = TestPublisher::new(42);
+    let mut publisher2 = TestPublisher::new(24);
 
-//     bus.add_subscriber(subscriber1);
-//     bus.add_subscriber(subscriber2);
-//     bus.add_publisher(&mut publisher1);
-//     bus.add_publisher(&mut publisher2);
+    bus.add_subscriber(subscriber1);
+    bus.add_subscriber(subscriber2);
+    bus.add_publisher(&mut publisher1);
+    bus.add_publisher(&mut publisher2);
 
-//     publisher1.publish_to(0);
-//     publisher1.publish_to(1);
-//     publisher1.publish_to(2);
-//     publisher1.publish_to(3);
+    publisher1.publish_to(0);
+    publisher1.publish_to(1);
+    publisher1.publish_to(2);
+    publisher1.publish_to(3);
 
-//     publisher2.publish_to(0);
-//     publisher2.publish_to(1);
-//     publisher2.publish_to(2);
-//     publisher2.publish_to(3);
-// }
+    publisher2.publish_to(0);
+    publisher2.publish_to(1);
+    publisher2.publish_to(2);
+    publisher2.publish_to(3);
+}

--- a/src/publisher/tests.rs
+++ b/src/publisher/tests.rs
@@ -40,7 +40,7 @@ impl TestPublisher {
             value: self.publisher_value,
         };
 
-        self.emitter.publish(event);
+        self.emitter.publish(event, None);
     }
 }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -14,10 +14,10 @@ use super::Event;
 #[cfg(test)]
 mod tests;
 
-pub trait Subscriber<ContentType> {
-    fn get_subscribed_topics(&self) -> Option<Vec<u32>> {
+pub trait Subscriber<ContentType, TopicId> {
+    fn get_subscribed_topics(&self) -> Option<Vec<TopicId>> {
         None
     }
 
-    fn on_event(&mut self, event: &Event<ContentType>);
+    fn on_event(&mut self, event: &Event<ContentType, TopicId>);
 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -8,13 +8,14 @@
 // site:    https://agramakov.me
 // e-mail:  mail@agramakov.me
 //
-// *************************************************************************
+// *************************************************************************\
+
 use super::BusEvent;
 
 #[cfg(test)]
 mod tests;
 
-pub trait Subscriber<ContentType, TopicId> {
+pub trait Subscriber<ContentType, TopicId>: Send + Sync {
     fn get_subscribed_topics(&self) -> Option<Vec<TopicId>> {
         None
     }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -16,6 +16,9 @@ use super::BusEvent;
 mod tests;
 
 /// A trait that defines a subscriber to the event bus.
+/// Override get_subscribed_topics to return a list of topics the subscriber is interested in.
+/// If the subscriber is interested in all topics, thre si a default implementation that returns None.
+/// Override on_event to handle the event.
 pub trait Subscriber<ContentType, TopicId>: Send + Sync {
     fn get_subscribed_topics(&self) -> Option<Vec<TopicId>> {
         None

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -9,7 +9,7 @@
 // e-mail:  mail@agramakov.me
 //
 // *************************************************************************
-use super::Event;
+use super::BusEvent;
 
 #[cfg(test)]
 mod tests;
@@ -19,5 +19,5 @@ pub trait Subscriber<ContentType, TopicId> {
         None
     }
 
-    fn on_event(&mut self, event: &Event<ContentType, TopicId>);
+    fn on_event(&mut self, event: &BusEvent<ContentType, TopicId>);
 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -15,6 +15,7 @@ use super::BusEvent;
 #[cfg(test)]
 mod tests;
 
+/// A trait that defines a subscriber to the event bus.
 pub trait Subscriber<ContentType, TopicId>: Send + Sync {
     fn get_subscribed_topics(&self) -> Option<Vec<TopicId>> {
         None

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -15,5 +15,9 @@ use super::Event;
 mod tests;
 
 pub trait Subscriber<ContentType> {
+    fn get_subscribed_topics(&self) -> Option<Vec<u32>> {
+        None
+    }
+
     fn on_event(&mut self, event: &Event<ContentType>);
 }

--- a/src/subscriber/tests.rs
+++ b/src/subscriber/tests.rs
@@ -26,7 +26,7 @@ struct TestPublisher {
 
 impl TestPublisher {
     pub fn publish(&mut self, val: i32) {
-        self.publisher.publish(val);
+        self.publisher.publish(val, None);
     }
 }
 

--- a/src/subscriber/tests.rs
+++ b/src/subscriber/tests.rs
@@ -1,55 +1,39 @@
-// use crate::event::Event;
-// use crate::subscriber::Subscriber;
-// use crate::{EventBus, EventEmitter, Publisher};
-// use std::sync::{Arc, Mutex};
+use crate::subscriber::Subscriber;
+use crate::{BusEvent, EventBus};
+use std::sync::{Arc, Mutex};
 
-// struct TestSubscriber {
-//     attribute: i32,
-// }
+struct TestSubscriber {
+    attribute: i32,
+}
 
-// impl Subscriber<i32> for TestSubscriber {
-//     fn on_event(&mut self, event: &Event<i32>) {
-//         let id = event.get_id();
-//         println!(
-//             "Received event with id: {} and content: {}",
-//             id,
-//             event.get_content()
-//         );
+impl Subscriber<i32, u32> for TestSubscriber {
+    fn on_event(&mut self, event: &BusEvent<i32, u32>) {
+        let id = event.get_id();
+        println!(
+            "Received event with id: {} and content: {}",
+            id,
+            event.get_content()
+        );
 
-//         self.attribute = *event.get_content();
-//     }
-// }
+        self.attribute = *event.get_content();
+    }
+    
+    fn get_subscribed_topics(&self) -> Option<Vec<u32>> {
+        Some(vec![42])
+    }
+}
 
-// struct TestPublisher {
-//     pub publisher: EventEmitter<i32>,
-// }
+#[test]
+fn test_subscriber() {
+    let bus: Arc<EventBus<i32, u32>> = Arc::new(EventBus::new());
 
-// impl TestPublisher {
-//     pub fn publish(&mut self, val: i32) {
-//         self.publisher.publish(val, None);
-//     }
-// }
+    let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
+    bus.add_subscriber(subscriber.clone());
 
-// impl Publisher<i32> for TestPublisher {
-//     fn get_mut_emitter(&mut self) -> &mut EventEmitter<i32> {
-//         &mut self.publisher
-//     }
-// }
-
-// #[test]
-// fn test_subscriber() {
-//     let bus: Arc<EventBus<i32>> = Arc::new(EventBus::new());
-
-//     let mut publisher = TestPublisher {
-//         publisher: EventEmitter::new(),
-//     };
-//     let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
-
-//     bus.add_subscriber(subscriber.clone());
-//     bus.add_publisher(&mut publisher);
-
-//     publisher.publish(42);
-//     assert_eq!(subscriber.lock().unwrap().attribute, 42);
-//     publisher.publish(24);
-//     assert_eq!(subscriber.lock().unwrap().attribute, 24);
-// }
+    bus.publish(42, Some(42));
+    assert_eq!(subscriber.lock().unwrap().attribute, 42);
+    
+    // The subscriber is not subscribed to this topic
+    bus.publish(24, Some(24));
+    assert_eq!(subscriber.lock().unwrap().attribute, 42);
+}

--- a/src/subscriber/tests.rs
+++ b/src/subscriber/tests.rs
@@ -28,7 +28,7 @@ fn test_subscriber() {
     let bus: EventBus<i32, u32> = EventBus::new();
 
     let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
-    bus.add_subscriber(subscriber.clone());
+    bus.add_subscriber_shared(subscriber.clone());
 
     bus.publish(42, Some(42));
     assert_eq!(subscriber.lock().unwrap().attribute, 42);

--- a/src/subscriber/tests.rs
+++ b/src/subscriber/tests.rs
@@ -25,7 +25,7 @@ impl Subscriber<i32, u32> for TestSubscriber {
 
 #[test]
 fn test_subscriber() {
-    let bus: Arc<EventBus<i32, u32>> = Arc::new(EventBus::new());
+    let bus: EventBus<i32, u32> = EventBus::new();
 
     let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
     bus.add_subscriber(subscriber.clone());

--- a/src/subscriber/tests.rs
+++ b/src/subscriber/tests.rs
@@ -30,10 +30,10 @@ fn test_subscriber() {
     let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
     bus.add_subscriber_shared(subscriber.clone());
 
-    bus.publish(42, Some(42));
+    bus.publish(42, Some(42), 0);
     assert_eq!(subscriber.lock().unwrap().attribute, 42);
     
     // The subscriber is not subscribed to this topic
-    bus.publish(24, Some(24));
+    bus.publish(24, Some(24), 1);
     assert_eq!(subscriber.lock().unwrap().attribute, 42);
 }

--- a/src/subscriber/tests.rs
+++ b/src/subscriber/tests.rs
@@ -1,55 +1,55 @@
-use crate::event::Event;
-use crate::subscriber::Subscriber;
-use crate::{EventBus, EventEmitter, Publisher};
-use std::sync::{Arc, Mutex};
+// use crate::event::Event;
+// use crate::subscriber::Subscriber;
+// use crate::{EventBus, EventEmitter, Publisher};
+// use std::sync::{Arc, Mutex};
 
-struct TestSubscriber {
-    attribute: i32,
-}
+// struct TestSubscriber {
+//     attribute: i32,
+// }
 
-impl Subscriber<i32> for TestSubscriber {
-    fn on_event(&mut self, event: &Event<i32>) {
-        let id = event.get_id();
-        println!(
-            "Received event with id: {} and content: {}",
-            id,
-            event.get_content()
-        );
+// impl Subscriber<i32> for TestSubscriber {
+//     fn on_event(&mut self, event: &Event<i32>) {
+//         let id = event.get_id();
+//         println!(
+//             "Received event with id: {} and content: {}",
+//             id,
+//             event.get_content()
+//         );
 
-        self.attribute = *event.get_content();
-    }
-}
+//         self.attribute = *event.get_content();
+//     }
+// }
 
-struct TestPublisher {
-    pub publisher: EventEmitter<i32>,
-}
+// struct TestPublisher {
+//     pub publisher: EventEmitter<i32>,
+// }
 
-impl TestPublisher {
-    pub fn publish(&mut self, val: i32) {
-        self.publisher.publish(val, None);
-    }
-}
+// impl TestPublisher {
+//     pub fn publish(&mut self, val: i32) {
+//         self.publisher.publish(val, None);
+//     }
+// }
 
-impl Publisher<i32> for TestPublisher {
-    fn get_mut_emitter(&mut self) -> &mut EventEmitter<i32> {
-        &mut self.publisher
-    }
-}
+// impl Publisher<i32> for TestPublisher {
+//     fn get_mut_emitter(&mut self) -> &mut EventEmitter<i32> {
+//         &mut self.publisher
+//     }
+// }
 
-#[test]
-fn test_subscriber() {
-    let bus: Arc<EventBus<i32>> = Arc::new(EventBus::new());
+// #[test]
+// fn test_subscriber() {
+//     let bus: Arc<EventBus<i32>> = Arc::new(EventBus::new());
 
-    let mut publisher = TestPublisher {
-        publisher: EventEmitter::new(),
-    };
-    let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
+//     let mut publisher = TestPublisher {
+//         publisher: EventEmitter::new(),
+//     };
+//     let subscriber = Arc::new(Mutex::new(TestSubscriber { attribute: 0 }));
 
-    bus.add_subscriber(subscriber.clone());
-    bus.add_publisher(&mut publisher);
+//     bus.add_subscriber(subscriber.clone());
+//     bus.add_publisher(&mut publisher);
 
-    publisher.publish(42);
-    assert_eq!(subscriber.lock().unwrap().attribute, 42);
-    publisher.publish(24);
-    assert_eq!(subscriber.lock().unwrap().attribute, 24);
-}
+//     publisher.publish(42);
+//     assert_eq!(subscriber.lock().unwrap().attribute, 42);
+//     publisher.publish(24);
+//     assert_eq!(subscriber.lock().unwrap().attribute, 24);
+// }


### PR DESCRIPTION
- Add topics, so subscribers can receive only events they subscribed.
- Hide thread-safety related details
- Add unique publisher ID to event header as `source_id`
- Add `EventBus::add_subscriber_shared` to add subscriber without move
- Expose Publisher::publish()
- Huge refactoring and clean up.